### PR TITLE
fix: change nodejs version to 20 to complete build CI/CD pipeline wit…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the Node.js version used in both the CI and deployment GitHub Actions workflows from version 18 to version 20. This ensures that our automated workflows are running on a more recent and supported Node.js version.

Workflow updates:

* Updated the Node.js version from 18 to 20 in the CI workflow configuration file `.github/workflows/ci.yml`.
* Updated the Node.js version from 18 to 20 in the deployment workflow configuration file `.github/workflows/deploy.yml`.