### PR TITLE
fix(build): update production build command and add SPA routing support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,11 @@ jobs:
         run: npm ci
 
       - name: Build (production)
-        run: npm run build:prod
+        run: npm run build:prod -- --base-href /Easy-Task/
 
+      - name: Copy index.html to 404.html for SPA routing
+        run: cp dist/tmp/browser/index.html dist/tmp/browser/404.html
+#
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This pull request updates the deployment workflow to improve support for single-page application (SPA) routing when deploying to GitHub Pages. The most important changes are:

Deployment workflow improvements:

* Modified the build step in `.github/workflows/deploy.yml` to set the `--base-href` to `/Easy-Task/`, ensuring correct asset paths when the app is served from a subdirectory.
* Added a step to copy `index.html` to `404.html` in the build output directory, which enables client-side routing to work correctly on GitHub Pages by redirecting unknown routes to the SPA entry point.