### PR TITLE
fix(deploy): remove unnecessary comment in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Copy index.html to 404.html for SPA routing
         run: cp dist/tmp/browser/index.html dist/tmp/browser/404.html
 
+      - name: Create .nojekyll file to disable Jekyll
+        run: touch dist/tmp/browser/.nojekyll
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow by removing an unnecessary comment in the `.github/workflows/deploy.yml` file. The change does not affect functionality but helps keep the workflow file clean.