### PR TITLE
fix(deploy): update branch name from 'main' to 'master' in GitHub Pag…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 permissions:
   contents: read


### PR DESCRIPTION
…es workflow
This pull request makes a small configuration change to the GitHub Actions deployment workflow. The workflow is now set to trigger on pushes to the `master` branch instead of the `main` branch.