### PR TITLE
fix(header): correct image source path in header component

### DIFF
--- a/src/app/components/header/header.html
+++ b/src/app/components/header/header.html
@@ -1,6 +1,6 @@
 <header
   class="flex flex-col items-center gap-4 w-[90%] max-w-[50rem] mx-auto mb-8 text-center bg-gradient-to-b from-[#2c0a4c] to-[#450d80] p-4 md:p-8 rounded-b-xl shadow-[0_1px_8px_rgba(0,0,0,0.6)]">
-  <img src="/assets/task-management-logo.png" alt="todo list logo" class="w-14 md:w-[4.5rem] object-contain">
+  <img src="assets/task-management-logo.png" alt="todo list logo" class="w-14 md:w-[4.5rem] object-contain">
   <div>
     <h1 class="text-amber-50 text-xl md:text-2xl m-0 p-0">Easy Task</h1>
     <p class="m-0 text-[0.8rem] [text-wrap:balance]">Enterprise-level task management without friction</p>


### PR DESCRIPTION
This pull request makes a small update to the image path in the header component. The leading slash was removed from the `src` attribute of the logo image to ensure the asset loads correctly in different deployment environments.

* Changed the image path in `header.html` from `/assets/task-management-logo.png` to `assets/task-management-logo.png` to fix asset loading issues.